### PR TITLE
에외처리 로직을 작성한다.

### DIFF
--- a/chatting/src/main/java/com/chatting/application/UserAccountService.java
+++ b/chatting/src/main/java/com/chatting/application/UserAccountService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.chatting.domain.useraccount.UserAccount;
 import com.chatting.domain.useraccount.UserAccountRepository;
 import com.chatting.exception.BusinessException;
+import com.chatting.exception.ErrorCode;
 import com.chatting.presentation.dto.request.SignUpRequest;
 import com.chatting.presentation.dto.response.SignUpResponse;
 
@@ -31,13 +32,13 @@ public class UserAccountService {
 
 	private void validate(final SignUpRequest request) {
 		if (userAccountRepository.existsByEmail(request.email())) {
-			throw new BusinessException("동일한 이메일이 존재합니다.");
+			throw new BusinessException("동일한 이메일이 존재합니다.", ErrorCode.UA_SIGNUP);
 		}
 		if (userAccountRepository.existsByLoginId(request.loginId())) {
-			throw new BusinessException("동일한 로그인 아이디가 존재합니다.");
+			throw new BusinessException("동일한 로그인 아이디가 존재합니다.", ErrorCode.UA_SIGNUP);
 		}
 		if (userAccountRepository.existsByNickname(request.nickname())) {
-			throw new BusinessException("동일한 닉네임이 존재합니다.");
+			throw new BusinessException("동일한 닉네임이 존재합니다.", ErrorCode.UA_SIGNUP);
 		}
 	}
 }

--- a/chatting/src/main/java/com/chatting/exception/BusinessException.java
+++ b/chatting/src/main/java/com/chatting/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.chatting.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public BusinessException(final String message, final ErrorCode errorCode) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+}

--- a/chatting/src/main/java/com/chatting/exception/ControllerAdvice.java
+++ b/chatting/src/main/java/com/chatting/exception/ControllerAdvice.java
@@ -1,0 +1,16 @@
+package com.chatting.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ErrorResponse> handleBusiness(final BusinessException e) {
+		return ResponseEntity
+			.badRequest()
+			.body(ErrorResponse.from(e.getMessage(), e.getErrorCode()));
+	}
+}

--- a/chatting/src/main/java/com/chatting/exception/ErrorCode.java
+++ b/chatting/src/main/java/com/chatting/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.chatting.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+	// USER_ACCOUNT
+	UA_SIGNUP("회원가입 중 에러 발생");
+
+	private final String description;
+
+	ErrorCode(final String description) {
+		this.description = description;
+	}
+}

--- a/chatting/src/main/java/com/chatting/exception/ErrorResponse.java
+++ b/chatting/src/main/java/com/chatting/exception/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.chatting.exception;
+
+public record ErrorResponse(
+	String errorMessage,
+	ErrorCode errorCode
+) {
+
+	public static ErrorResponse from(final String errorMessage, final ErrorCode errorCode) {
+		return new ErrorResponse(errorMessage, errorCode);
+	}
+}


### PR DESCRIPTION
## Issue
* [x] #7

## 변경사항
* 애플리케이션 서버에서 비즈니스 로직 수행 중 잘못된 결과에 대해 응답을 반환하기 위해서 예외처리 로직을 작성
  * Spring Framework에서 제공하는 `@RestControllerAdvice` 사용
  * 에러가 발생할 경우 로그를 남겨야 하는데, 어떤 것을 로그로 남겨할 지는 추후 고민하도록 하겠습니다.
* ErrorCode Enum
  * 모든 예외상황별 `RuntimeException` 을 상속한 커스텀 예외를 만들 수도 있지만 `ErrorCode` 클래스를 두었습니다.
  * 커스텀 예외를 만들 경우 클래스 파일의 개수가 늘어나 관리해야할 클래스가 많아진다는 단점 때문에 위와 같이 기능 구현했습니다.

## 결과 화면
![image](https://user-images.githubusercontent.com/66981851/222888192-b0553e60-ca56-4f9a-b80f-86a653172099.png)

중복된 이메일에 대해 `예외메시지`와 `에러코드`를 함께 반환하도록 기능 구현

This closes #7 